### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["/assets"]
 description = "Fast and memory saving bsdiff 4.x compatible delta compressor and patcher."
 
 [dependencies]
-bzip2 = "0.4"
+bzip2 = "0.4.4"
 byteorder = "1.4"
 rayon = "1.5"
 suffix_array = "0.5"


### PR DESCRIPTION
Updates bzip dependency to the patch version of 0.4.4

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0004.html)
[fix](https://github.com/alexcrichton/bzip2-rs/pull/86)