### PR TITLE
Allow patching from a Read-er rather than a buffer.

### DIFF
--- a/src/bspatch.rs
+++ b/src/bspatch.rs
@@ -106,6 +106,19 @@ impl<'p> Bspatch<'p> {
         let ctx = Context::new(self.patch, curs, target, self.buffer_size, delta_min);
         ctx.apply()
     }
+
+    /// Apply patch to Read + Seek source data and output the stream of
+    /// target.
+    ///
+    /// This allows passing e.g. a std::fs::File and not pre-reading all
+    /// the data into memory.
+    ///
+    /// The target data size would be returned if no error occurs.
+    pub fn apply_reader<S: Read + Seek, T: Write>(self, source: S, target: T) -> Result<u64> {
+        let delta_min = Ord::min(self.delta_min, self.buffer_size);
+        let ctx = Context::new(self.patch, source, target, self.buffer_size, delta_min);
+        ctx.apply()
+    }
 }
 
 /// Patch file content.

--- a/tests/compatible.rs
+++ b/tests/compatible.rs
@@ -19,6 +19,12 @@ fn regular_samples_compat() {
             panic!("bsdiff/qbspatch incompatible: `{}`", sample.name);
         }
 
+        let sf = sample.load_source_file().unwrap();
+        let t1f = testing.qbspatch_read(&sf, &p1[..]).unwrap();
+        if t1f != t1 {
+            panic!("qbspatch/qbspatch_read incompatible: `{}`", sample.name);
+        }
+
         let p2 = testing.qbsdiff(&s[..], &t[..]).unwrap();
         let t2 = testing.bspatch(&s[..], &p2[..]).unwrap();
         if t2 != t {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsStr;
 use std::fs;
 use std::io;
-use std::io::Read;
+use std::io::{Read, Seek};
 use std::path;
 use std::path::Path;
 use std::process;
@@ -97,6 +97,14 @@ impl Testing {
         let patcher = Bspatch::new(p)?;
         let mut t = Vec::with_capacity(patcher.hint_target_size() as usize);
         patcher.apply(s, io::Cursor::new(&mut t))?;
+        Ok(t)
+    }
+
+    /// Perform qbspatch with a Reader-ly source.
+    pub fn qbspatch_read(&self, s: impl Read + Seek, p: &[u8]) -> io::Result<Vec<u8>> {
+        let patcher = Bspatch::new(p)?;
+        let mut t = Vec::with_capacity(patcher.hint_target_size() as usize);
+        patcher.apply_reader(s, io::Cursor::new(&mut t))?;
         Ok(t)
     }
 
@@ -331,6 +339,11 @@ impl Sample {
     /// Load source data.
     pub fn load_source(&self) -> io::Result<Vec<u8>> {
         Ok(fs::read(self.source.as_path())?)
+    }
+
+    /// Load source data as a File.
+    pub fn load_source_file(&self) -> io::Result<fs::File> {
+        fs::File::open(self.source.as_path())
     }
 
     /// Load target data.


### PR DESCRIPTION
This allows patching a file in a more streaming way, without pre-loading the whole thing into memory.

I think there's an argument to be made that this should be the _only_ interface, and if somebody wants to buffer up in memory they should wrap a Cursor around a Vec or something themselves.  After all, the output is just a Write-r, not a memory buffer; why shouldn't the input be similar?  That would be a significant compat break though, and would presumably mean a major version.  So this parallel API implementation was chosen.