### PR TITLE
chore: update dependencies to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ exclude = ["/assets"]
 description = "Fast and memory saving bsdiff 4.x compatible delta compressor and patcher."
 
 [dependencies]
+byteorder = "1.5"
 bzip2 = "0.4.4"
-byteorder = "1.4"
-rayon = "1.5"
+clap = { optional = true, version = "4.5", features = ["derive"] }
+rayon = "1.10"
 suffix_array = "0.5"
-clap = { optional = true, version = "3.2", features = [ "derive" ] }
 
 [dev-dependencies]
-qbsdiff_test_bench_utils = { version ="0.1", path = "utils" }
-criterion = { version = "0.3", features = [ "html_reports" ] }
+criterion = { version = "0.5", features = ["html_reports"] }
+qbsdiff_test_bench_utils = { version = "0.1", path = "utils" }
 
 [features]
 default = []
-cmd = ["clap"]
+cmd = ["dep:clap"]
 
 [[bin]]
 name = "qbsdiff"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/hucsmn/qbsdiff"
 description = "private utilities of the qbsdiff crate for tests and benchmarks"
 
 [dependencies]
-qbsdiff = { version ="1", path = ".." }
-globwalk = "0.8"
-rand = "0.8"
 chrono = "0.4"
+globwalk = "0.9"
+qbsdiff = { version = "1", path = ".." }
+rand = "0.8"


### PR DESCRIPTION
also sorted, and made `clap` dependency not show up in the features list